### PR TITLE
v2: avoid sscanf use (for atoi)

### DIFF
--- a/firmware/controllers/settings.cpp
+++ b/firmware/controllers/settings.cpp
@@ -1105,17 +1105,23 @@ void printDateTime() {
 #endif // EFI_RTC
 }
 
-void setDateTime(const char * const isoDateTime) {
+void setDateTime(char const * const isoDateTime) {
 #if EFI_RTC
 	if (strlen(isoDateTime) >= 19 && isoDateTime[10] == 'T') {
 		efidatetime_t dateTime;
-		int scanned = sscanf(isoDateTime, "%4lu", &dateTime.year);
-		scanned += sscanf(isoDateTime + 5, "%2hhu", &dateTime.month);
-		scanned += sscanf(isoDateTime + 8, "%2hhu", &dateTime.day);
-		scanned += sscanf(isoDateTime + 11, "%2hhu", &dateTime.hour);
-		scanned += sscanf(isoDateTime + 14, "%2hhu", &dateTime.minute);
-		scanned += sscanf(isoDateTime + 17, "%2hhu", &dateTime.second);
-		if (scanned == 6) { // 6 fields to properly scan
+		dateTime.year = atoi(isoDateTime);
+		dateTime.month = atoi(isoDateTime + 5);
+		dateTime.day = atoi(isoDateTime + 8);
+		dateTime.hour = atoi(isoDateTime + 11);
+		dateTime.minute = atoi(isoDateTime + 14);
+		dateTime.second = atoi(isoDateTime + 17);
+		if (dateTime.year != ATOI_ERROR_CODE &&
+				dateTime.month >= 1 && dateTime.month <= 12 &&
+				dateTime.day >= 1 && dateTime.day <= 31 &&
+				dateTime.hour <= 23 &&
+				dateTime.minute <= 59 &&
+				dateTime.second <= 59) {
+			// doesn't concern about leap years or seconds; ChibiOS doesn't support (added) leap seconds anyway
 			setRtcDateTime(&dateTime);
 			return;
 		}

--- a/firmware/controllers/settings.h
+++ b/firmware/controllers/settings.h
@@ -20,4 +20,4 @@ void setEngineType(int value);
 void readPin(const char *pinName);
 
 void printDateTime();
-void setDateTime(const char * const isoDateTime);
+void setDateTime(char const * const isoDateTime);

--- a/firmware/util/efilib.cpp
+++ b/firmware/util/efilib.cpp
@@ -81,8 +81,7 @@ int indexOf(const char *string, char ch) {
 }
 
 // string to integer
-int atoi(const char *string) {
-	// todo: use stdlib '#include <stdlib.h> '
+int atoi(char const * const string) {
 	int len = strlen(string);
 	if (len == 0) {
 		return -ATOI_ERROR_CODE;
@@ -95,7 +94,11 @@ int atoi(const char *string) {
 	for (int i = 0; i < len; i++) {
 		char ch = string[i];
 		if (ch < '0' || ch > '9') {
-			return ATOI_ERROR_CODE;
+			if (i > 0) {
+				break;
+			} else {
+				return ATOI_ERROR_CODE;
+			}
 		}
 		int c = ch - '0';
 		result = result * 10 + c;

--- a/firmware/util/efilib.h
+++ b/firmware/util/efilib.h
@@ -62,7 +62,7 @@ int efiPow10(int param);
 bool startsWith(const char *line, const char *prefix);
 int indexOf(const char *string, char ch);
 float atoff(const char *string);
-int atoi(const char *string);
+int atoi(char const * const string);
 
 #define UNUSED(x) (void)(x)
 


### PR DESCRIPTION
to avoid bloating the stack, for https://github.com/rusefi/rusefi/issues/4881 (via https://github.com/rusefi/rusefi/pull/4880)

(v2 of #2; avoiding `(char *)` cast via tweaking `atoi` more in-line w/ stdlib: break on later non-digit vs fail)

----

`set date` (automatic, via console)
```
2022-12-07_22_14_05_615: EngineState: confirmation_set date 2022-12-07T22:14:05.383:32
```
`get date` (manual, via console)
```
2022-12-07_22_14_08_688: EngineState: Current RTC time: 07 Dec 2022 22:14:08
2022-12-07_22_14_08_689: EngineState: confirmation_get date:8
```